### PR TITLE
make request with proofIds instead of hashids

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -65,8 +65,8 @@ async function getProofs(proofHandles) {
     )
 
   try {
-    // Collect together all proof UUIDs destined for a single Node
-    // so they can be submitted to the Node in a single request.
+    // Collect together all proof UUIDs destined for a single Gateway
+    // so they can be submitted to the Gateway in a single request.
     let uuidsByNode = {}
     forEach(proofHandles, handle => {
       if (isEmpty(uuidsByNode[handle.uri])) {
@@ -75,9 +75,9 @@ async function getProofs(proofHandles) {
       uuidsByNode[handle.uri].push(handle.proofId)
     })
 
-    // For each Node construct a set of GET options including
-    // the `hashids` header with a list of all hash ID's to retrieve
-    // proofs for from that Node.
+    // For each Gateway construct a set of GET options including
+    // the `proofIds` header with a list of all hash ID's to retrieve
+    // proofs for from that Gateway.
     let nodesWithGetOpts = map(keys(uuidsByNode), node => {
       let headers = Object.assign(
         {
@@ -85,7 +85,7 @@ async function getProofs(proofHandles) {
           'content-type': 'application/json'
         },
         {
-          hashids: uuidsByNode[node].join(',')
+          proofIds: uuidsByNode[node].join(',')
         },
         isSecureOrigin()
           ? {
@@ -103,7 +103,7 @@ async function getProofs(proofHandles) {
       return getOptions
     })
 
-    // Perform parallel GET requests to all Nodes with proofs
+    // Perform parallel GET requests to all Gateways with proofs
     const parsedBody = await fetchEndpoints(nodesWithGetOpts)
     // fetchEndpoints returns an Array entry for each host it submits to.
     let flatParsedBody = flatten(parsedBody)


### PR DESCRIPTION
fixes a bug that was causing getProofs to fail 